### PR TITLE
feat: localize volume parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dynamic = ["version"]
 dependencies = [
     "music-assistant-models-loose==0.0.1",
     "ovos-bus-client>=0.0.10,<2.0.0",
+    "ovos-number-parser>=0.0.1,<1.0.0",
     "ovos-plugin-manager>=0.8.3",
     "ovos-utils>=0.7.0",
     "ovos-workshop<1.0.0,>=0.0.15,>=0.0.16,~=0.0",

--- a/skill_musicassistant/__init__.py
+++ b/skill_musicassistant/__init__.py
@@ -4,6 +4,7 @@ import requests
 from music_assistant_models.enums import MediaType, QueueOption
 from music_assistant_models.errors import MusicAssistantError
 from music_assistant_models.player import Player
+from ovos_number_parser import extract_number
 from ovos_bus_client import Message
 from ovos_utils.process_utils import RuntimeRequirements
 from ovos_workshop.decorators import intent_handler
@@ -229,6 +230,47 @@ class MusicAssistantSkill(OVOSSkill):
         self.gui.show_text(f"{message}. Check the logs for more details.")
         self.speak_dialog("generic_could_not", {"thing": message})
 
+    def _load_volume_aliases(self):
+        """Load locale-specific volume aliases."""
+        cache_key = f"{self.lang}:volume_levels.value"
+        if cache_key not in self.resources.static:
+            aliases = {}
+            try:
+                values = self.resources.load_named_value_file("volume_levels").items()
+            except FileNotFoundError:
+                values = []
+            for name, value in values:
+                key = name.lower().strip()
+                raw = str(value).strip().lower()
+                try:
+                    aliases[key] = int(raw)
+                except ValueError:
+                    aliases[key] = raw
+            self.resources.static[cache_key] = aliases
+        return self.resources.static[cache_key]
+
+    def _load_cached_list(self, name: str):
+        """Load and cache a locale list resource."""
+        cache_key = f"{self.lang}:{name}.list"
+        if cache_key not in self.resources.static:
+            try:
+                values = self.resources.load_list_file(name) or []
+            except FileNotFoundError:
+                values = []
+            self.resources.static[cache_key] = values
+        return self.resources.static[cache_key]
+
+    def _get_volume_action(self, message: Message):
+        """Extract mute actions from the localized utterance."""
+        utterance = message.data.get("utterance", "")
+        if not utterance:
+            return None
+        if self.voc_match(utterance, "unmute", lang=self.lang):
+            return "unmute"
+        if self.voc_match(utterance, "mute", lang=self.lang):
+            return "mute"
+        return None
+
     @intent_handler("play_artist.intent")
     def handle_play_artist(self, message: Message):
         """Handle playing an artist"""
@@ -342,8 +384,20 @@ class MusicAssistantSkill(OVOSSkill):
             if not player_id:
                 return
 
-            # Parse volume level (could be "50", "fifty", "half", etc.)
-            volume = self._parse_volume_level(str(volume_level))
+            action = self._get_volume_action(message)
+            if action == "unmute":
+                self.log.info("Unmuting player %s", player_id)
+                self.mass_client.player_command_volume_mute(player_id, muted=False)
+                self.speak_dialog("volume_unmuted")
+                return
+            if action == "mute":
+                self.log.info("Muting player %s", player_id)
+                self.mass_client.player_command_volume_mute(player_id, muted=True)
+                self.speak_dialog("volume_muted")
+                return
+
+            # Parse volume level (could be "50", "fifty", "moitié", etc.)
+            volume = self._parse_volume_level(volume_level)
             if volume == "up":
                 self.mass_client.player_command_volume_up(player_id)
                 self.speak_dialog("volume_up")
@@ -351,18 +405,6 @@ class MusicAssistantSkill(OVOSSkill):
             if volume == "down":
                 self.mass_client.player_command_volume_down(player_id)
                 self.speak_dialog("volume_down")
-                return
-            if volume is None and "mute" in message.data:
-                if "unmute" in message.data:
-                    self.log.info("Unmuting player %s", player_id)
-                    self.mass_client.player_command_volume_mute(player_id, muted=False)
-                    self.speak_dialog("volume_unmuted")
-                    return
-                else:
-                    self.log.info("Muting player %s", player_id)
-                    self.mass_client.player_command_volume_mute(player_id, muted=True)
-                    self.speak_dialog("volume_muted")
-                    return
                 return
             if volume is None:
                 self.log.error("Invalid volume level: %s", volume_level)
@@ -386,51 +428,32 @@ class MusicAssistantSkill(OVOSSkill):
         if not volume_input:
             return None
 
-        volume_input = volume_input.lower().strip()
+        volume_input = str(volume_input).lower().strip()
 
         # Handle numeric input
         if volume_input.isdigit():
             vol = int(volume_input)
             return max(0, min(100, vol))
 
-        # Handle word-based volumes
-        # TODO: Use OVOS libraries so we can be language agnostic
-        volume_words = {
-            "zero": 0,
-            "off": 0,
-            "mute": 0,
-            "ten": 10,
-            "twenty": 20,
-            "thirty": 30,
-            "forty": 40,
-            "fifty": 50,
-            "sixty": 60,
-            "seventy": 70,
-            "eighty": 80,
-            "ninety": 90,
-            "hundred": 100,
-            "low": 25,
-            "medium": 50,
-            "high": 75,
-            "max": 100,
-            "maximum": 100,
-            "quiet": 25,
-            "loud": 75,
-            "half": 50,
-            "full": 100,
-            "up": "up",
-            "down": "down",
-        }
+        aliases = self._load_volume_aliases()
+        if volume_input in aliases:
+            return aliases[volume_input]
 
-        if volume_input in volume_words:
-            return volume_words[volume_input]
+        # Handle localized percent suffixes before full number parsing so
+        # phrases like "trente pour cent" don't get misread as 100.
+        for suffix in ["%", *self._load_cached_list("percent_phrases")]:
+            if suffix and volume_input.endswith(suffix):
+                num_part = volume_input[: -len(suffix)].strip()
+                if num_part.isdigit():
+                    vol = int(num_part)
+                    return max(0, min(100, vol))
+                volume = extract_number(num_part, lang=self.lang)
+                if volume is not None and volume is not False:
+                    return max(0, min(100, int(volume)))
 
-        # Handle "percent" suffix
-        if volume_input.endswith(" percent") or volume_input.endswith("%"):
-            num_part = volume_input.replace(" percent", "").replace("%", "")
-            if num_part.isdigit():
-                vol = int(num_part)
-                return max(0, min(100, vol))
+        volume = extract_number(volume_input, lang=self.lang)
+        if volume is not None and volume is not False:
+            return max(0, min(100, int(volume)))
 
         return None
 

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -1,7 +1,7 @@
 """Integration tests for the MusicAssistantSkill class."""
 
 from typing import cast
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
 from music_assistant_models.enums import MediaType
@@ -145,15 +145,38 @@ class TestMusicAssistantSkillIntegration:
 
     def test_parse_volume_level_words(self, skill):
         """Test volume level parsing with word input."""
-        assert skill._parse_volume_level("mute") == 0
-        assert skill._parse_volume_level("half") == 50
-        assert skill._parse_volume_level("max") == 100
-        assert skill._parse_volume_level("loud") == 75
+        with patch.object(
+            skill,
+            "_load_volume_aliases",
+            return_value={"mute": 0, "half": 50, "max": 100, "loud": 75},
+        ):
+            assert skill._parse_volume_level("mute") == 0
+            assert skill._parse_volume_level("half") == 50
+            assert skill._parse_volume_level("max") == 100
+            assert skill._parse_volume_level("loud") == 75
 
     def test_parse_volume_level_percent(self, skill):
         """Test volume level parsing with percent notation."""
-        assert skill._parse_volume_level("75%") == 75
-        assert skill._parse_volume_level("25 percent") == 25
+        with patch.object(skill, "_load_cached_list", return_value=["percent"]):
+            assert skill._parse_volume_level("75%") == 75
+            assert skill._parse_volume_level("25 percent") == 25
+
+    def test_parse_volume_level_french(self, skill):
+        """Test volume parsing with French words."""
+        with (
+            patch.object(type(skill), "lang", new_callable=PropertyMock, return_value="fr-fr"),
+            patch.object(
+                skill,
+                "_load_volume_aliases",
+                return_value={"moitié": 50, "plus fort": "up", "moins fort": "down"},
+            ),
+            patch.object(skill, "_load_cached_list", return_value=["pour cent"]),
+        ):
+            assert skill._parse_volume_level("trente") == 30
+            assert skill._parse_volume_level("trente pour cent") == 30
+            assert skill._parse_volume_level("moitié") == 50
+            assert skill._parse_volume_level("plus fort") == "up"
+            assert skill._parse_volume_level("moins fort") == "down"
 
     def test_parse_volume_level_invalid(self, skill):
         """Test volume level parsing with invalid input."""
@@ -227,6 +250,25 @@ class TestSkillMessageHandlers:
 
             skill_with_mocks.mass_client.queue_command_previous.assert_called_once_with("test-player")
             skill_with_mocks.speak_dialog.assert_called_once_with("previous_track")
+
+    def test_handle_volume_mute_with_localized_utterance(self, skill_with_mocks):
+        """Test mute handling via localized utterance matching."""
+        mock_message = Mock()
+        mock_message.data = {"utterance": "avec music assistant coupe le son"}
+
+        with (
+            patch.object(type(skill_with_mocks), "lang", new_callable=PropertyMock, return_value="fr-fr"),
+            patch.object(skill_with_mocks, "_get_player", return_value="test-player"),
+            patch.object(
+                skill_with_mocks,
+                "voc_match",
+                side_effect=lambda utt, voc_filename, lang=None: voc_filename == "mute",
+            ),
+        ):
+            skill_with_mocks.handle_volume(mock_message)
+
+        skill_with_mocks.mass_client.player_command_volume_mute.assert_called_once_with("test-player", muted=True)
+        skill_with_mocks.speak_dialog.assert_called_once_with("volume_muted")
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -585,6 +585,19 @@ wheels = [
 ]
 
 [[package]]
+name = "ovos-number-parser"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "quebra-frases" },
+    { name = "unicode-rbnf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/84/9271f7ca2a4b9ab9e4d8e7cade1642764a1c0d44c112bbbce9025a7315cc/ovos-number-parser-0.5.1.tar.gz", hash = "sha256:3a5c771a25bf801fcf35ab6923185de8f96f4b3710104d65be2b57f06dffe437", size = 126723, upload-time = "2025-10-12T16:56:53.615Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/e2/9701592e8b5001d982aa73fe4c734ef86e21d1483fa96707ae477160205a/ovos_number_parser-0.5.1-py3-none-any.whl", hash = "sha256:15e47ed2df6415f053b4e3bae418eaca7520a43ab0c5e98292b0a0838e0934cc", size = 149472, upload-time = "2025-10-12T16:56:52.28Z" },
+]
+
+[[package]]
 name = "ovos-plugin-manager"
 version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1113,6 +1126,7 @@ source = { editable = "." }
 dependencies = [
     { name = "music-assistant-models-loose" },
     { name = "ovos-bus-client" },
+    { name = "ovos-number-parser" },
     { name = "ovos-plugin-manager" },
     { name = "ovos-utils" },
     { name = "ovos-workshop" },
@@ -1133,6 +1147,7 @@ requires-dist = [
     { name = "music-assistant-models-loose", specifier = "==0.0.1" },
     { name = "mypy", marker = "extra == 'test'", specifier = ">=1.15.0" },
     { name = "ovos-bus-client", specifier = ">=0.0.10,<2.0.0" },
+    { name = "ovos-number-parser", specifier = ">=0.0.1,<1.0.0" },
     { name = "ovos-plugin-manager", specifier = ">=0.8.3" },
     { name = "ovos-utils", specifier = ">=0.7.0" },
     { name = "ovos-workshop", specifier = "~=0.0,>=0.0.15,>=0.0.16,<1.0.0" },
@@ -1199,6 +1214,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673, upload-time = "2025-07-04T13:28:34.16Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906, upload-time = "2025-07-04T13:28:32.743Z" },
+]
+
+[[package]]
+name = "unicode-rbnf"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/1f/d952ba97832647e608700c36b22d1c4476016076c9ed1ce74ae814bea55a/unicode_rbnf-2.4.0.tar.gz", hash = "sha256:6d2f12a7581c69ea6218ee61fafcd2da46e1f9986bdcd0964c5151f7c2a938ac", size = 89069, upload-time = "2025-10-07T20:59:41.3Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/21/82f5d435808cba330668a8b69efb180e3ef9739d4998e8cd0381e8c9cb23/unicode_rbnf-2.4.0-py3-none-any.whl", hash = "sha256:0176b30ac9b7b84008d7dc0f23078055dc10d2671fdadfab5747943243e20e2d", size = 141691, upload-time = "2025-10-07T20:59:40.139Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- replace the English-only volume parser with locale-aware parsing
- use  for spoken number extraction
- detect mute and unmute actions from localized vocab files and the raw utterance
- add focused tests for French parsing and localized mute handling

## Notes
- code-only PR
- depends on the locale resource files added in #20
