### PR TITLE
fix: remove unused play_artist.dialog

### DIFF
--- a/skill.json
+++ b/skill.json
@@ -28,5 +28,5 @@
         "music assistant",
         "open home foundation"
     ],
-    "version": "0.2.0"
+    "version": "0.2.2"
 }

--- a/skill_musicassistant/locale/en-us/dialog/play_artist.dialog
+++ b/skill_musicassistant/locale/en-us/dialog/play_artist.dialog
@@ -1,1 +1,0 @@
-Playing {track_name} by {artist_name}.

--- a/skill_musicassistant/locale/en-us/skill.json
+++ b/skill_musicassistant/locale/en-us/skill.json
@@ -28,5 +28,5 @@
         "music assistant",
         "open home foundation"
     ],
-    "version": "0.2.0"
+    "version": "0.2.2"
 }


### PR DESCRIPTION
`handle_play_artist` speaks the `playing` dialog on success, never `play_artist`. The `play_artist.dialog` file is byte-identical to `playing.dialog` and has no references anywhere in the codebase — it's been dead since the handler was written.

Confirmed during the May 2026 standardization audit:
- Only code references to `play_artist` are the **intent** (`play_artist.intent`, retained) and the handler name.
- `diff play_artist.dialog playing.dialog` → identical.
- No string references to the dialog name in any `.py`/`.json`.
- Only `en-us/` had the file (no other locales to clean).

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)