### PR TITLE
fix: prune Padatious intent expansion from 4,232 to 520 samples

### DIFF
--- a/skill.json
+++ b/skill.json
@@ -28,5 +28,5 @@
         "music assistant",
         "open home foundation"
     ],
-    "version": "0.3.1"
+    "version": "0.4.0"
 }

--- a/skill_musicassistant/locale/en-us/intents/next.intent
+++ b/skill_musicassistant/locale/en-us/intents/next.intent
@@ -1,7 +1,8 @@
 # Next Track Intent
 next
 skip
-(next|skip)(|this ) (track|song|station|title)
+(next|skip) (track|song|station|title)
+(next|skip) this (track|song)
 
 # With location
-(next|skip) (track|song|station|title) (in|on) (the|) {location}
+(next|skip) (track|song) (in|on) (the|) {location}

--- a/skill_musicassistant/locale/en-us/intents/pause.intent
+++ b/skill_musicassistant/locale/en-us/intents/pause.intent
@@ -3,14 +3,11 @@ pause
 pause (the|) (music|playback|player|audio)
 
 # With location
-pause (the|) (music|playback|player|audio) (in|on) (the|) {location}
+pause (the|) (music|playback) (in|on) (the|) {location}
 
 # Resume variants
-unpause (the|) (music|playback|player|audio)
-resume (the|) (music|playback|player|audio)
-continue playing (the|) (music|playback|player|audio)
+(unpause|resume) (the|) (music|playback|player|audio)
+continue playing (the|) (music|playback)
 
 # Resume with location
-unpause (the|) (music|playback|player|audio) (in|on) (the|) {location}
-resume (the|) (music|playback|player|audio) (in|on) (the|) {location}
-continue playing (the|) (music|playback|player|audio) (in|on) (the|) {location}
+(unpause|resume) (the|) music (in|on) (the|) {location}

--- a/skill_musicassistant/locale/en-us/intents/play_album.intent
+++ b/skill_musicassistant/locale/en-us/intents/play_album.intent
@@ -1,29 +1,21 @@
 # Play Album Intent - Requires explicit album/ep/record keywords
+# Keep alternation fan-out low: Padatious generalizes from base forms, so
+# every verb x keyword x slot combination must NOT be enumerated (see #30)
 play (the|) (album|ep|record|compilation|single) {album}
-listen to (the|) (album|ep|record|compilation|single) {album}
-shuffle (the|) (album|ep|record|compilation|single) {album}
+(listen to|shuffle) (the|) (album|record) {album}
 
 # With artist
-play (the|) (album|ep|record|compilation|single) {album} by (the|) (artist|band|group) {artist}
-listen to (the|) (album|ep|record|compilation|single) {album} by (the|) (artist|band|group) {artist}
-shuffle (the|) (album|ep|record|compilation|single) {album} by (the|) (artist|band|group) {artist}
+play (the|) (album|record) {album} by {artist}
+play (the|) album {album} by (the|) (artist|band|group) {artist}
+(listen to|shuffle) (the|) album {album} by {artist}
 
 # With location
-play (the|) (album|ep|record|compilation|single) {album} (in|on|using) (the|) {location}
-listen to (the|) (album|ep|record|compilation|single) {album} (in|on|using) (the|) {location}
-shuffle (the|) (album|ep|record|compilation|single) {album} (in|on|using) (the|) {location}
+play (the|) (album|record) {album} (in|on|using) (the|) {location}
+(listen to|shuffle) (the|) album {album} on (the|) {location}
 
 # With artist and location
-play (the|) (album|ep|record|compilation|single) {album} by (the|) (artist|band|group) {artist} (in|on|using) (the|) {location}
-listen to (the|) (album|ep|record|compilation|single) {album} by (the|) (artist|band|group) {artist} (in|on|using) (the|) {location}
-shuffle (the|) (album|ep|record|compilation|single) {album} by (the|) (artist|band|group) {artist} (in|on|using) (the|) {location}
+play (the|) album {album} by {artist} (in|on|using) (the|) {location}
 
 # With radio mode
-play (the|) (album|ep|record|compilation|single) {album} (with|using) radio mode
-listen to (the|) (album|ep|record|compilation|single) {album} (with|using) radio mode
-play (the|) (album|ep|record|compilation|single) {album} by (the|) (artist|band|group) {artist} (with|using) radio mode
-listen to (the|) (album|ep|record|compilation|single) {album} by (the|) (artist|band|group) {artist} (with|using) radio mode
-
-# Complete patterns with all options
-play (the|) (album|ep|record|compilation|single) {album} by (the|) (artist|band|group) {artist} (in|on|using) (the|) {location} (with|using) radio mode
-listen to (the|) (album|ep|record|compilation|single) {album} by (the|) (artist|band|group) {artist} (in|on|using) (the|) {location} (with|using) radio mode
+play (the|) album {album} (with|using) radio mode
+play (the|) album {album} by {artist} (with|using) radio mode

--- a/skill_musicassistant/locale/en-us/intents/play_artist.intent
+++ b/skill_musicassistant/locale/en-us/intents/play_artist.intent
@@ -1,14 +1,10 @@
+# Play Artist Intent - Requires explicit artist/band keywords or songs/music by
+# Keep alternation fan-out low - Padatious generalizes from base forms (see #30)
 play (the|) (artist|band|group) {artist}
-listen to (the|) (artist|band|group) {artist}
-shuffle (the|) (artist|band|group) {artist}
+(listen to|shuffle) (the|) (artist|band|group) {artist}
 
-play (the|) (artist|band|group) {artist} (in|on|using) (the|) {location}
-listen to (the|) (artist|band|group) {artist} (in|on|using) (the|) {location}
-shuffle (the|) (artist|band|group) {artist} (in|on|using) (the|) {location}
+# With location
+play (the|) (artist|band) {artist} (in|on|using) (the|) {location}
 
-shuffle songs by {artist}
-shuffle music by {artist}
-play songs by {artist}
-play music by {artist}
-listen to songs by {artist}
-listen to music by {artist}
+# Songs/music by
+(play|shuffle|listen to) (songs|music) by {artist}

--- a/skill_musicassistant/locale/en-us/intents/play_radio.intent
+++ b/skill_musicassistant/locale/en-us/intents/play_radio.intent
@@ -1,19 +1,15 @@
 # Play Radio Intent - Requires explicit radio/station keywords or tune verbs
+# Keep alternation fan-out low - Padatious generalizes from base forms (see #30)
 play (the|) (radio station|radio|station) {radio_station}
-listen to (the|) (radio station|radio|station) {radio_station}
+listen to (the|) (radio|station) {radio_station}
 
 # With location
-play (the|) (radio station|radio|station) {radio_station} (in|on|using) (the|) {location}
-listen to (the|) (radio station|radio|station) {radio_station} (in|on|using) (the|) {location}
+play (the|) (radio|station) {radio_station} (in|on|using) (the|) {location}
 
 # Tune verbs are unambiguous
-tune into {radio_station}
-tune to {radio_station}
-tune into {radio_station} (in|on|using) (the|) {location}
-tune to {radio_station} (in|on|using) (the|) {location}
+tune (into|to) {radio_station}
+tune (into|to) {radio_station} (in|on|using) (the|) {location}
 
 # Station-specific patterns with "radio" suffix
 play {radio_station} radio
 listen to {radio_station} radio
-play {radio_station} radio (in|on|using) (the|) {location}
-listen to {radio_station} radio (in|on|using) (the|) {location}

--- a/skill_musicassistant/locale/en-us/intents/play_track.intent
+++ b/skill_musicassistant/locale/en-us/intents/play_track.intent
@@ -1,15 +1,15 @@
 # Play Track Intent - Requires explicit track/song keywords
+# Keep alternation fan-out low - Padatious generalizes from base forms (see #30)
 play (the|) (track|song) {track}
 listen to (the|) (track|song) {track}
 
 # With artist
-play (the|) (track|song) {track} by (the|) (artist|band|group) {artist}
-listen to (the|) (track|song) {track} by (the|) (artist|band|group) {artist}
+play (the|) (track|song) {track} by {artist}
+play (the|) song {track} by (the|) (artist|band|group) {artist}
+listen to (the|) song {track} by {artist}
 
 # With location
 play (the|) (track|song) {track} (in|on|using) (the|) {location}
-listen to (the|) (track|song) {track} (in|on|using) (the|) {location}
 
 # With artist and location
-play (the|) (track|song) {track} by (the|) (artist|band|group) {artist} (in|on|using) (the|) {location}
-listen to (the|) (track|song) {track} by (the|) (artist|band|group) {artist} (in|on|using) (the|) {location}
+play (the|) song {track} by {artist} (in|on|using) (the|) {location}

--- a/skill_musicassistant/locale/en-us/intents/previous.intent
+++ b/skill_musicassistant/locale/en-us/intents/previous.intent
@@ -2,9 +2,7 @@
 previous
 rewind
 (|go )back
-previous (track|song|station|title)
-last (track|song|station|title)
+(previous|last) (track|song|station|title)
 
 # With location
-previous (track|song|station|title) (in|on) (the|) {location}
-last (track|song|station|title) (in|on) (the|) {location}
+(previous|last) (track|song) (in|on) (the|) {location}

--- a/skill_musicassistant/locale/en-us/skill.json
+++ b/skill_musicassistant/locale/en-us/skill.json
@@ -28,5 +28,5 @@
         "music assistant",
         "open home foundation"
     ],
-    "version": "0.3.1"
+    "version": "0.4.0"
 }

--- a/test/test_intents.py
+++ b/test/test_intents.py
@@ -1,0 +1,111 @@
+"""Guardrails for intent file size and matching.
+
+Padatious expands every (a|b|c) group into separate training samples and uses
+other intents' samples as negatives, so training cost grows superlinearly with
+total sample count. These tests keep the expansion budget from creeping back up
+(see issue #30) and verify the kept phrasings still match their intents.
+"""
+
+from pathlib import Path
+
+import pytest
+from ovos_utils.bracket_expansion import expand_template
+from padacioso import IntentContainer
+
+LOCALE_DIR = Path(__file__).parent.parent / "skill_musicassistant" / "locale"
+
+# Hard ceilings from issue #30 - raise these only with a measured justification
+MAX_SAMPLES_PER_LOCALE = 600
+MAX_SAMPLES_PER_FILE = 200
+
+
+def _intent_lines(path: Path):
+    return [
+        line.strip()
+        for line in path.read_text().splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+
+
+def _expansion_counts(lang: str):
+    intent_dir = LOCALE_DIR / lang / "intents"
+    return {
+        f.name: sum(len(expand_template(line)) for line in _intent_lines(f))
+        for f in sorted(intent_dir.glob("*.intent"))
+    }
+
+
+class TestExpansionBudget:
+    @pytest.mark.parametrize("lang", ["en-us", "fr-fr"])
+    def test_locale_total_under_budget(self, lang):
+        counts = _expansion_counts(lang)
+        total = sum(counts.values())
+        assert total <= MAX_SAMPLES_PER_LOCALE, (
+            f"{lang} intents expand to {total} Padatious samples "
+            f"(budget {MAX_SAMPLES_PER_LOCALE}): {counts}"
+        )
+
+    @pytest.mark.parametrize("lang", ["en-us", "fr-fr"])
+    def test_no_single_file_dominates(self, lang):
+        for name, count in _expansion_counts(lang).items():
+            assert count <= MAX_SAMPLES_PER_FILE, (
+                f"{lang}/{name} expands to {count} samples (budget {MAX_SAMPLES_PER_FILE}) "
+                "- prune alternation groups instead of enumerating combinations"
+            )
+
+
+class TestIntentMatching:
+    """Exact-pattern matching for the phrasings the intent files keep.
+
+    Uses padacioso (regex, deterministic). Padatious additionally generalizes
+    beyond these patterns at runtime; this suite covers the guaranteed floor.
+    """
+
+    @pytest.fixture(scope="class")
+    def container(self):
+        container = IntentContainer()
+        intent_dir = LOCALE_DIR / "en-us" / "intents"
+        for f in sorted(intent_dir.glob("*.intent")):
+            container.add_intent(f.stem, _intent_lines(f))
+        return container
+
+    @pytest.mark.parametrize(
+        "utterance,intent",
+        [
+            ("play the album abbey road", "play_album"),
+            ("shuffle the album abbey road", "play_album"),
+            ("play the album abbey road by the beatles", "play_album"),
+            ("play the album abbey road by the beatles in the kitchen", "play_album"),
+            ("play the album abbey road with radio mode", "play_album"),
+            ("play the track yellow submarine", "play_track"),
+            ("play the song yellow submarine by the beatles", "play_track"),
+            ("play the song yellow submarine in the kitchen", "play_track"),
+            ("play the artist caravan palace", "play_artist"),
+            ("shuffle music by daft punk", "play_artist"),
+            ("play the band caravan palace on the office speaker", "play_artist"),
+            ("play the playlist focus", "play_playlist"),
+            ("play the playlist focus in the kitchen", "play_playlist"),
+            ("tune into kexp", "play_radio"),
+            ("play the radio station kexp", "play_radio"),
+            ("play kexp radio", "play_radio"),
+            ("pause the music", "pause"),
+            ("resume the music", "pause"),
+            ("pause the music in the kitchen", "pause"),
+            ("next track", "next"),
+            ("skip this song", "next"),
+            ("previous track", "previous"),
+            ("go back", "previous"),
+            ("make the office speaker my default speaker", "set_default_player"),
+            ("change my default player to the kitchen display", "set_default_player"),
+            ("set the music volume to 50", "volume"),
+        ],
+    )
+    def test_utterance_matches_intent(self, container, utterance, intent):
+        result = container.calc_intent(utterance)
+        assert result.get("name") == intent, f"{utterance!r} -> {result}"
+
+    def test_slots_extracted(self, container):
+        result = container.calc_intent("play the album abbey road by the beatles in the kitchen")
+        assert result["entities"].get("album") == "abbey road"
+        assert result["entities"].get("artist") == "the beatles"
+        assert result["entities"].get("location") == "kitchen"


### PR DESCRIPTION
Closes #30

## Results

Measured with `ovos_utils.bracket_expansion.expand_template` (same expansion Padatious applies at training time):

| | Before | After |
|---|---|---|
| en-us total | **4,232** | **520** |
| play_album.intent | 3,190 | 90 |
| play_track.intent | 392 | 62 |
| pause.intent | 161 | 61 |
| play_artist.intent | 132 | 48 |
| play_radio.intent | 112 | 50 |

fr-fr untouched — it was already written flat (from the #19 review) at 120 samples.

## Approach

- Deleted the fully-combined lines (verb × `(album|ep|record|compilation|single)` × artist × location × radio-mode — the two "complete patterns" lines in play_album expanded to 720 samples *each*). Padatious is a neural matcher that generalizes from base forms; it does not need every combination enumerated.
- Kept one canonical line per slot *structure* (base, +artist, +location, +artist+location, +radio-mode) with slimmed alternations, so each slot position is still represented in training — and exact-pattern matchers (padacioso fallback) still have a template for every structure.
- **Bonus matching improvement:** added keyword-free `by {artist}` forms. Previously "play the album Abbey Road by The Beatles" only trained with a mandatory `(artist|band|group)` keyword ("...by the artist The Beatles"); the natural phrasing now has an exact template.
- **Bug fix:** `next.intent` had `(next|skip)(|this )` which expanded to garbage training samples like `"nextthis  song"` (no space between groups). Split into two clean lines.

## Regression protection

New `test/test_intents.py`:
- **Budget guard:** total expansion ≤ 600 per locale, ≤ 200 per file — future intent edits fail CI if the explosion creeps back.
- **Match floor:** trains a padacioso container from the real intent files and asserts 26 representative utterances (including full combos like "play the album abbey road by the beatles in the kitchen") match the right intent, plus slot-extraction checks. Padacioso is exact-pattern, so this is the guaranteed floor; Padatious generalizes further at runtime.

## Caveat

On cores where Padatious is unavailable and padacioso is the intent matcher (rare — ovos-padatious is a hard dep of ovos-core), phrasings that relied on the deleted combination lines and aren't covered by a kept template will no longer match exactly. The kept templates cover every slot structure, so the practical loss is exotic verb+keyword combos ("listen to the compilation X by the group Y using the kitchen with radio mode").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
